### PR TITLE
removed the online tests from test task, and added a test_all task

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ There are three "environments" set up for pixi:
 - `dev`
 - `examples`
 
-And two "tasks": 
+And three "tasks":
 
 - `lint`
-- `test`
+- `test` : run most of the tests
+- `test_all` : run the tests that access AWS -- i.e. download data directly.
 
 To run the tests in an isolated environment:
 
@@ -90,25 +91,26 @@ To run the tests in an isolated environment:
 pixi run -e dev test
 ```
 
+Or with a specific python version:
+```bash
+pixi run -e test312 test
+```
+
+Options are: `test310` `test311` `test312` `test313`
+
+
 To run a shell to do dev work:
 
 ```bash
 pixi shell -e dev
 ```
 
-If you want to run the examples (notebooks and al that):
-
-```bash
-pixi shell -e all
-```
-
-That will set up a conda environment with all the develop dependencies.
-
-To run a shell in which you can run the examples:
+To run a shell in which you can run the examples (notebooks and al that):
 
 ```bash
 pixi shell -e examples
 ```
+
 To run a shell with everything (dev and example deps:
 
 ```bash

--- a/pixi.lock
+++ b/pixi.lock
@@ -25509,8 +25509,8 @@ packages:
   timestamp: 1745980911520
 - pypi: ./
   name: xarray-subset-grid
-  version: 0.1.dev82+ga60a450
-  sha256: 50f8b34ae97dff7908d5ac0e160f685b8397b839ad086a757fee378bc321e3bc
+  version: 0.1.dev83+g7a4bbfd.d20250606
+  sha256: 7d09d83f7e162b369bdddc8da93d2585d5cb8cd54c25761fb215f7898ed85d39
   requires_dist:
   - numpy
   - xarray>=2024.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,8 @@ python-build = "*"
 
 [tool.pixi.feature.dev.tasks]
 lint = "ruff check tests xarray_subset_grid"
-test = "pytest --online tests/"
+test = "pytest tests/"
+test_all = "pytest --online tests/"
 
 [tool.pixi.feature.examples.dependencies]
 matplotlib = "*"


### PR DESCRIPTION
Adds a pixi task for testing either all or without the online tests.

The online tests need help, but this at least gets it so the CI would pass, and tests *some* of what we need.
