### PR TITLE
Reformat with ruff format

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -25509,8 +25509,8 @@ packages:
   timestamp: 1745980911520
 - pypi: ./
   name: xarray-subset-grid
-  version: 0.1.dev82+ga60a450
-  sha256: 50f8b34ae97dff7908d5ac0e160f685b8397b839ad086a757fee378bc321e3bc
+  version: 0.1.dev85+ge509d10
+  sha256: b9c84e6038d90d71be0b9947e53e9453b86e105353d0e5af6b8fbfa27c76bbf4
   requires_dist:
   - numpy
   - xarray>=2024.6

--- a/profiling/STOFS_benchmarks.py
+++ b/profiling/STOFS_benchmarks.py
@@ -6,8 +6,8 @@ import thalassa
 import xarray as xr
 import xugrid as xu
 
-bucket_name = 'noaa-gestofs-pds'
-key = '_para2/stofs_2d_glo.20230819/stofs_2d_glo.t00z.fields.cwl.nc'
+bucket_name = "noaa-gestofs-pds"
+key = "_para2/stofs_2d_glo.20230819/stofs_2d_glo.t00z.fields.cwl.nc"
 url = f"s3://{bucket_name}/{key}"
 
 fs = fsspec.filesystem("s3", anon=True)
@@ -16,30 +16,31 @@ ds = xr.open_dataset(
     fs.open(url),
     chunks={},
     drop_variables=["neta", "nvel", "max_nvdll", "max_nvell"],
-    engine='h5netcdf'
+    engine="h5netcdf",
 )
 
 bbox = (-70, 40, -60, 50)
 
+
 def info(ds):
-    print(f'Data Variables: {ds.data_vars}')
-    print(f'Coordinates: {ds.coords}')
-    print(f'Dimensions: {ds.dims}')
-    print(f'Attributes: {ds.attrs}\n')
+    print(f"Data Variables: {ds.data_vars}")
+    print(f"Coordinates: {ds.coords}")
+    print(f"Dimensions: {ds.dims}")
+    print(f"Attributes: {ds.attrs}\n")
 
 
 print("Subsetting methods comparison")
 start = time.time()
 ads = ds.xsg.grid.subset_bbox(ds, bbox)
-print(f"Xarray-subset-grid - {time.time-start} sec")
+print(f"Xarray-subset-grid - {time.time - start} sec")
 
 start = time.time()
 tds = thalassa.normalize(ds)
 tds = thalassa.crop(tds, shapely.box(*bbox))
-print(f"Thalassa - {time.time-start} sec")
+print(f"Thalassa - {time.time - start} sec")
 
 # Checking time only for subsetting operation
 uds = xu.UgridDataset(ds)
 start = time.time()
 uds = uds.ugrid.sel(y=slice(bbox[2], bbox[3]), x=slice(bbox[0], bbox[1]))
-print(f"UGrid - {time.time-start} sec")
+print(f"UGrid - {time.time - start} sec")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,18 @@ write_to = "xarray_subset_grid/_version.py"
 
 [tool.ruff]
 builtins = ["ellipsis"]
-extend-exclude = ["xarray_subset_grid/_version.py"]
+extend-exclude = ["xarray_subset_grid/_version.py", "docs"]
 target-version = "py310"
 # Use a longer line length.
 line-length = 100
+
+[tool.ruff.format]
+# Prefer single quotes over double quotes.
+quote-style = "double"
+# Use `\n` line endings for all files
+line-ending = "lf"
+exclude = ["*.ipynb"]
+
 
 [tool.ruff.lint]
 ignore = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     # register an additional marker
     config.addinivalue_line(
-        "markers",
-        "online: mark test to run only when online (using AWS resources)"
+        "markers", "online: mark test to run only when online (using AWS resources)"
     )
 
 

--- a/tests/test_grids/test_regular_grid.py
+++ b/tests/test_grids/test_regular_grid.py
@@ -12,7 +12,7 @@ import xarray as xr
 
 from xarray_subset_grid.grids.regular_grid import RegularGrid
 
-TEST_DATA = Path(__file__).parent.parent / 'example_data'
+TEST_DATA = Path(__file__).parent.parent / "example_data"
 
 TEST_FILE1 = TEST_DATA / "AMSEAS-subset.nc"
 
@@ -23,6 +23,7 @@ It was created by the "OFS subsetter"
 
 """
 
+
 def test_recognise():
     """
     works for at least one file ...
@@ -31,6 +32,7 @@ def test_recognise():
 
     assert RegularGrid.recognize(ds)
 
+
 def test_recognise_not():
     """
     should not recognise an SGrid
@@ -38,8 +40,6 @@ def test_recognise_not():
     ds = xr.open_dataset(TEST_DATA / "arakawa_c_test_grid.nc")
 
     assert not RegularGrid.recognize(ds)
-
-
 
 
 #######

--- a/tests/test_grids/test_sgrid.py
+++ b/tests/test_grids/test_sgrid.py
@@ -11,44 +11,55 @@ from xarray_subset_grid.grids.sgrid import _get_location_info_from_topology
 try:
     import fsspec
     import zarr
+
     zarr__version__ = int(zarr.__version__.split(".")[0])
 except ImportError:
     fsspec = None
 
 
-test_dir = Path(__file__).parent.parent / 'example_data'
+test_dir = Path(__file__).parent.parent / "example_data"
 
-sample_sgrid_file = test_dir / 'arakawa_c_test_grid.nc'
+sample_sgrid_file = test_dir / "arakawa_c_test_grid.nc"
+
 
 def test_grid_topology_location_parse():
     ds = xr.open_dataset(sample_sgrid_file, decode_times=False)
-    node_info = _get_location_info_from_topology(ds['grid'], 'node')
-    edge1_info  = _get_location_info_from_topology(ds['grid'], 'edge1')
-    edge2_info = _get_location_info_from_topology(ds['grid'], 'edge2')
-    face_info = _get_location_info_from_topology(ds['grid'], 'face')
+    node_info = _get_location_info_from_topology(ds["grid"], "node")
+    edge1_info = _get_location_info_from_topology(ds["grid"], "edge1")
+    edge2_info = _get_location_info_from_topology(ds["grid"], "edge2")
+    face_info = _get_location_info_from_topology(ds["grid"], "face")
 
-    assert node_info == {'dims': ['xi_psi', 'eta_psi'],
-                         'coords': ['lon_psi', 'lat_psi'],
-                         'padding': {'xi_psi': 'none', 'eta_psi': 'none'}}
-    assert edge1_info == {'dims': ['xi_u', 'eta_u'],
-                          'coords': ['lon_u', 'lat_u'],
-                          'padding': {'eta_u': 'both', 'xi_u': 'none'}}
-    assert edge2_info == {'dims': ['xi_v', 'eta_v'],
-                          'coords': ['lon_v', 'lat_v'],
-                          'padding': {'xi_v': 'both', 'eta_v': 'none'}}
-    assert face_info == {'dims': ['xi_rho', 'eta_rho'],
-                         'coords': ['lon_rho', 'lat_rho'],
-                         'padding': {'xi_rho': 'both', 'eta_rho': 'both'}}
+    assert node_info == {
+        "dims": ["xi_psi", "eta_psi"],
+        "coords": ["lon_psi", "lat_psi"],
+        "padding": {"xi_psi": "none", "eta_psi": "none"},
+    }
+    assert edge1_info == {
+        "dims": ["xi_u", "eta_u"],
+        "coords": ["lon_u", "lat_u"],
+        "padding": {"eta_u": "both", "xi_u": "none"},
+    }
+    assert edge2_info == {
+        "dims": ["xi_v", "eta_v"],
+        "coords": ["lon_v", "lat_v"],
+        "padding": {"xi_v": "both", "eta_v": "none"},
+    }
+    assert face_info == {
+        "dims": ["xi_rho", "eta_rho"],
+        "coords": ["lon_rho", "lat_rho"],
+        "padding": {"xi_rho": "both", "eta_rho": "both"},
+    }
 
 
-@pytest.mark.skipif(zarr__version__>=3,
-                    reason="zarr3.0.8 doesn't support FSpec AWS (it might soon)")
+@pytest.mark.skipif(
+    zarr__version__ >= 3, reason="zarr3.0.8 doesn't support FSpec AWS (it might soon)"
+)
 @pytest.mark.online
 def test_polygon_subset():
-    '''
+    """
     This is a basic integration test for the subsetting of a ROMS sgrid dataset using
     a polygon.
-    '''
+    """
     if fsspec is None:
         raise ImportError("Must have fsspec installed to run --online tests")
     fs = fsspec.filesystem(
@@ -61,9 +72,7 @@ def test_polygon_subset():
     )
     m = fs.get_mapper("")
 
-    ds = xr.open_dataset(
-        m, engine="zarr", backend_kwargs=dict(consolidated=False), chunks={}
-    )
+    ds = xr.open_dataset(m, engine="zarr", backend_kwargs=dict(consolidated=False), chunks={})
 
     polygon = np.array(
         [
@@ -77,46 +86,43 @@ def test_polygon_subset():
             [-122.38488806417945, 34.98888604471138],
         ]
     )
-    ds_temp = ds.xsg.subset_vars(['temp','u', 'v'])
+    ds_temp = ds.xsg.subset_vars(["temp", "u", "v"])
     ds_subset = ds_temp.xsg.subset_polygon(polygon)
 
     # Check that the subset dataset has the correct dimensions given the original padding
-    assert ds_subset.sizes['eta_rho'] == ds_subset.sizes['eta_psi'] + 1
-    assert ds_subset.sizes['eta_u'] == ds_subset.sizes['eta_psi'] + 1
-    assert ds_subset.sizes['eta_v'] == ds_subset.sizes['eta_psi']
-    assert ds_subset.sizes['xi_rho'] == ds_subset.sizes['xi_psi'] + 1
-    assert ds_subset.sizes['xi_u'] == ds_subset.sizes['xi_psi']
-    assert ds_subset.sizes['xi_v'] == ds_subset.sizes['xi_psi'] + 1
+    assert ds_subset.sizes["eta_rho"] == ds_subset.sizes["eta_psi"] + 1
+    assert ds_subset.sizes["eta_u"] == ds_subset.sizes["eta_psi"] + 1
+    assert ds_subset.sizes["eta_v"] == ds_subset.sizes["eta_psi"]
+    assert ds_subset.sizes["xi_rho"] == ds_subset.sizes["xi_psi"] + 1
+    assert ds_subset.sizes["xi_u"] == ds_subset.sizes["xi_psi"]
+    assert ds_subset.sizes["xi_v"] == ds_subset.sizes["xi_psi"] + 1
 
     # Check that the subset rho/psi/u/v positional relationship makes sense aka psi point is
     # 'between' it's neighbor rho points
     # Note that this needs to be better generalized; it's not trivial to write a test that
     # works in all potential cases.
-    assert (ds_subset['lon_rho'][0,0] < ds_subset['lon_psi'][0,0]
-            and ds_subset['lon_rho'][0,1] > ds_subset['lon_psi'][0,0])
+    assert (
+        ds_subset["lon_rho"][0, 0] < ds_subset["lon_psi"][0, 0]
+        and ds_subset["lon_rho"][0, 1] > ds_subset["lon_psi"][0, 0]
+    )
 
     # ds_subset.temp_sur.isel(ocean_time=0).plot(x="lon_rho", y="lat_rho")
 
+
 def test_polygon_subset_2():
     ds = xr.open_dataset(sample_sgrid_file, decode_times=False)
-    polygon = np.array([
-        [6.5, 37.5],
-        [6.5, 39.5],
-        [9.5, 40.5],
-        [8.5, 37.5],
-        [6.5, 37.5]
-    ])
+    polygon = np.array([[6.5, 37.5], [6.5, 39.5], [9.5, 40.5], [8.5, 37.5], [6.5, 37.5]])
     ds_subset = ds.xsg.subset_polygon(polygon)
 
-    #Check that the subset dataset has the correct dimensions given the original padding
-    assert ds_subset.sizes['eta_rho'] == ds_subset.sizes['eta_psi'] + 1
-    assert ds_subset.sizes['eta_u'] == ds_subset.sizes['eta_psi'] + 1
-    assert ds_subset.sizes['eta_v'] == ds_subset.sizes['eta_psi']
-    assert ds_subset.sizes['xi_rho'] == ds_subset.sizes['xi_psi'] + 1
-    assert ds_subset.sizes['xi_u'] == ds_subset.sizes['xi_psi']
-    assert ds_subset.sizes['xi_v'] == ds_subset.sizes['xi_psi'] + 1
+    # Check that the subset dataset has the correct dimensions given the original padding
+    assert ds_subset.sizes["eta_rho"] == ds_subset.sizes["eta_psi"] + 1
+    assert ds_subset.sizes["eta_u"] == ds_subset.sizes["eta_psi"] + 1
+    assert ds_subset.sizes["eta_v"] == ds_subset.sizes["eta_psi"]
+    assert ds_subset.sizes["xi_rho"] == ds_subset.sizes["xi_psi"] + 1
+    assert ds_subset.sizes["xi_u"] == ds_subset.sizes["xi_psi"]
+    assert ds_subset.sizes["xi_v"] == ds_subset.sizes["xi_psi"] + 1
 
     assert ds_subset.lon_psi.min() <= 6.5 and ds_subset.lon_psi.max() >= 9.5
     assert ds_subset.lat_psi.min() <= 37.5 and ds_subset.lat_psi.max() >= 40.5
 
-    assert 'u' in ds_subset.variables.keys()
+    assert "u" in ds_subset.variables.keys()

--- a/tests/test_grids/test_ugrid.py
+++ b/tests/test_grids/test_ugrid.py
@@ -270,6 +270,7 @@ def test_assign_ugrid_topology_min():
     for key, val in mesh.items():
         assert val
 
+
 def test_assign_ugrid_topology_dict():
     """
     FVCOM (SFBOFS):
@@ -295,6 +296,7 @@ def test_assign_ugrid_topology_dict():
     assert mesh["face_face_connectivity"] == "nbe"
     assert mesh["face_dimension"] == "nele"
 
+
 def test_assign_ugrid_topology_no_face_coords():
     """
     test for no face coords
@@ -305,10 +307,12 @@ def test_assign_ugrid_topology_no_face_coords():
     with pytest.raises(KeyError):
         ds["mesh"]
 
-    ds = ugrid.assign_ugrid_topology(ds, face_node_connectivity='tris',
-                                         node_coordinates = ('lon lat'),
-                                         boundary_node_connectivity = 'bounds'
-                                         )
+    ds = ugrid.assign_ugrid_topology(
+        ds,
+        face_node_connectivity="tris",
+        node_coordinates=("lon lat"),
+        boundary_node_connectivity="bounds",
+    )
 
     # there are others, but these are the ones that really matter.
     mesh = ds["mesh"].attrs
@@ -317,14 +321,16 @@ def test_assign_ugrid_topology_no_face_coords():
     assert mesh["face_node_connectivity"] == "tris"
     assert mesh["face_dimension"] == "tris"
 
-    assert mesh.keys() == {'cf_role',
-                         'topology_dimension',
-                         'face_node_connectivity',
-                         'boundary_node_connectivity',
-                         'node_coordinates',
-                         'face_dimension',
-                         'start_index',
-                         }
+    assert mesh.keys() == {
+        "cf_role",
+        "topology_dimension",
+        "face_node_connectivity",
+        "boundary_node_connectivity",
+        "node_coordinates",
+        "face_dimension",
+        "start_index",
+    }
+
 
 def test_assign_ugrid_topology_existing_mesh_var():
     """
@@ -384,7 +390,6 @@ def test_assign_ugrid_topology_start_index_zero_infer():
     assert ds["mesh_boundary_nodes"].attrs["start_index"] == 0
 
 
-
 # NOTE: these tests are probably not complete -- but they are something.
 #       we really should have a complete UGRID example to test with.
 def test_grid_vars():
@@ -427,6 +432,7 @@ def test_data_vars():
         ]
     )
 
+
 def test_assign_ugrid_topology_all():
     """
     it should use all the ones you pass in.
@@ -450,7 +456,7 @@ def test_assign_ugrid_topology_all():
 
     new_attrs = {}
     # clear out most of the mesh variable -- transfer to new attrs
-    mesh_attrs = ds['mesh'].attrs
+    mesh_attrs = ds["mesh"].attrs
     for key in tuple(mesh_attrs.keys()):
         if key not in {"cf_role", "long_name", "topology_dimension"}:
             new_attrs[key] = mesh_attrs.pop(key)
@@ -547,6 +553,7 @@ def test_vertical_levels():
         "siglay",
         "node",
     )
+
 
 @pytest.mark.online
 def test_3d_selector():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,14 @@ from xarray_subset_grid.utils import (
 
 # normalize_polygon_x_coords tests.
 
+
 def get_test_file_dir():
     """
     returns the test file dir path
     """
-    test_file_dir = os.path.join(os.path.dirname(__file__), 'example_data')
+    test_file_dir = os.path.join(os.path.dirname(__file__), "example_data")
     return test_file_dir
+
 
 poly1_180 = np.array(
     [

--- a/tests/test_visualization/test_mpl_plotting.py
+++ b/tests/test_visualization/test_mpl_plotting.py
@@ -78,6 +78,3 @@ def test_plot_ugrid_start_index_1():
 #     plot_sgrid(axis, ds, nodes=True)
 
 #     fig.savefig(OUTPUT_DIR / "sgrid_nodes")
-
-
-

--- a/xarray_subset_grid/__init__.py
+++ b/xarray_subset_grid/__init__.py
@@ -5,6 +5,6 @@ from . import utils  # noqa
 from . import accessor  # noqa
 from .selector import Selector
 
-from._version import __version__  # noqa
+from ._version import __version__  # noqa
 
-__all__ = ['Selector']
+__all__ = ["Selector"]

--- a/xarray_subset_grid/grid.py
+++ b/xarray_subset_grid/grid.py
@@ -135,7 +135,7 @@ class Grid(ABC):
     @abstractmethod
     def compute_polygon_subset_selector(
         self, ds: xr.Dataset, polygon: list[tuple[float, float]], name: str = None
-) -> Selector:
+    ) -> Selector:
         """Compute the subset selector for the polygon.
 
         This method will return a Selector that can be used to subset
@@ -148,10 +148,7 @@ class Grid(ABC):
         raise NotImplementedError()
 
     def compute_bbox_subset_selector(
-        self,
-        ds: xr.Dataset,
-        bbox: tuple[float, float, float, float],
-        name: str = None
+        self, ds: xr.Dataset, bbox: tuple[float, float, float, float], name: str = None
     ) -> Selector:
         """Compute the subset selector for the bounding box.
 
@@ -190,9 +187,7 @@ class Grid(ABC):
         selector = self.compute_polygon_subset_selector(ds, polygon)
         return selector.select(ds)
 
-    def subset_bbox(
-        self, ds: xr.Dataset, bbox: tuple[float, float, float, float]
-        ) -> xr.Dataset:
+    def subset_bbox(self, ds: xr.Dataset, bbox: tuple[float, float, float, float]) -> xr.Dataset:
         """Subset the dataset to the bounding box.
 
         This is a convenience method that will compute the subset

--- a/xarray_subset_grid/grids/__init__.py
+++ b/xarray_subset_grid/grids/__init__.py
@@ -1,6 +1,6 @@
-from .fvcom_grid import FVCOMGrid #noqa
-from .regular_grid import RegularGrid #noqa
-from .regular_grid_2d import RegularGrid2d #noqa
-from .selfe_grid import SELFEGrid #noqa
-from .sgrid import SGrid #noqa
-from .ugrid import UGrid #noqa
+from .fvcom_grid import FVCOMGrid  # noqa
+from .regular_grid import RegularGrid  # noqa
+from .regular_grid_2d import RegularGrid2d  # noqa
+from .selfe_grid import SELFEGrid  # noqa
+from .sgrid import SGrid  # noqa
+from .ugrid import UGrid  # noqa

--- a/xarray_subset_grid/grids/fvcom_grid.py
+++ b/xarray_subset_grid/grids/fvcom_grid.py
@@ -133,7 +133,8 @@ class FVCOMGrid(UGrid):
         if "siglev" in ds.dims:
             siglev = ds["siglev"].isel(node=0)
             elevation_index = [
-                int(np.absolute(siglev - level).argmin(axis=0).values) for level in levels]
+                int(np.absolute(siglev - level).argmin(axis=0).values) for level in levels
+            ]
             selections["siglev"] = slice(elevation_index[0], elevation_index[1])
 
         return ds.isel(selections)

--- a/xarray_subset_grid/grids/regular_grid.py
+++ b/xarray_subset_grid/grids/regular_grid.py
@@ -29,7 +29,7 @@ class RegularGridPolygonSelector(Selector):
 
     def __init__(
         self, polygon: list[tuple[float, float]] | np.ndarray, mask: xr.DataArray, name: str
-        ):
+    ):
         super().__init__()
         self.name = name
         self.polygon = polygon
@@ -113,7 +113,6 @@ class RegularGrid(Grid):
     def compute_polygon_subset_selector(
         self, ds: xr.Dataset, polygon: list[tuple[float, float]], name: str = None
     ) -> Selector:
-
         lat = ds.cf["latitude"]
         lon = ds.cf["longitude"]
 
@@ -122,10 +121,8 @@ class RegularGrid(Grid):
         polygon_mask = ray_tracing_numpy(x, lat.flat, polygon).reshape(lon.shape)
 
         selector = RegularGridPolygonSelector(
-            polygon=polygon,
-            mask=polygon_mask,
-            name=name or 'selector'
-            )
+            polygon=polygon, mask=polygon_mask, name=name or "selector"
+        )
         return selector
 
     def compute_bbox_subset_selector(

--- a/xarray_subset_grid/grids/regular_grid_2d.py
+++ b/xarray_subset_grid/grids/regular_grid_2d.py
@@ -12,7 +12,7 @@ class RegularGrid2dSelector(Selector):
 
     def __init__(
         self, polygon: list[tuple[float, float]] | np.ndarray, subset_mask: xr.DataArray, name: str
-        ):
+    ):
         super().__init__()
         self.name = name
         self.polygon = polygon
@@ -83,7 +83,6 @@ class RegularGrid2d(Grid):
     def compute_polygon_subset_selector(
         self, ds: xr.Dataset, polygon: list[tuple[float, float]], name: str = None
     ) -> Selector:
-
         lat = ds.cf["latitude"]
         lon = ds.cf["longitude"]
         subset_mask = compute_2d_subset_mask(lat=lat, lon=lon, polygon=polygon)
@@ -91,5 +90,5 @@ class RegularGrid2d(Grid):
         return RegularGrid2dSelector(
             polygon=polygon,
             subset_mask=subset_mask,
-            name=name or 'selector',
-            )
+            name=name or "selector",
+        )

--- a/xarray_subset_grid/grids/ugrid.py
+++ b/xarray_subset_grid/grids/ugrid.py
@@ -173,7 +173,6 @@ class UGrid(Grid):
     def compute_polygon_subset_selector(
         self, ds: xr.Dataset, polygon: list[tuple[float, float]], name: str = None
     ) -> Selector:
-
         # For this grid type, we find all nodes that are connected to elements that are inside
         # the polygon. To do this, we first find all nodes that are inside the polygon and then
         # find all elements that are connected to those nodes.
@@ -262,7 +261,7 @@ class UGrid(Grid):
                 face_face_new = face_face_new.T
 
         return UGridSelector(
-            name=name or 'selector',
+            name=name or "selector",
             polygon=polygon,
             node_dimension=node_dimension,
             selected_nodes=selected_nodes,
@@ -292,7 +291,7 @@ def assign_ugrid_topology(
     face_dimension: str | None = None,
     edge_dimension: str | None = None,
     start_index: int | None = None,
-    ) -> xr.Dataset:
+) -> xr.Dataset:
     # Should this be "make the entire dataset UGRID compliant ?"
     #    That would mean that the grid variables should all get metadata,
     #    such as "location"
@@ -385,7 +384,7 @@ def assign_ugrid_topology(
     # Use a SimpleNamespace for the attrs
     # it's easier to access than a dict, and easier to update than locals
     mesh = SimpleNamespace(
-        topology_dimension = np.int32(2),
+        topology_dimension=np.int32(2),
         face_node_connectivity=None,
         face_face_connectivity=None,
         boundary_node_connectivity=None,
@@ -398,15 +397,15 @@ def assign_ugrid_topology(
         face_dimension=None,
         edge_dimension=None,
         start_index=None,
-        )
+    )
     # Add in the existing ones from the Dataset mesh object
     mesh.__dict__.update(mesh_attrs)
 
     # Add in the ones passed in:
     variables = vars()
-    mesh.__dict__.update({att: variables[att]
-                          for att in ALL_MESH_VARS
-                          if variables[att] is not None})
+    mesh.__dict__.update(
+        {att: variables[att] for att in ALL_MESH_VARS if variables[att] is not None}
+    )
     mesh.start_index = start_index
 
     if mesh.face_node_connectivity is None:
@@ -416,8 +415,7 @@ def assign_ugrid_topology(
     if mesh.face_coordinates is None:
         try:
             face_coordinates = ds[mesh.face_node_connectivity].cf.coordinates
-            mesh.face_coordinates = " ".join(f"{coord[0]}"
-                                             for coord in face_coordinates.values())
+            mesh.face_coordinates = " ".join(f"{coord[0]}" for coord in face_coordinates.values())
         except AttributeError:
             mesh.face_coordinates = None
 
@@ -453,7 +451,6 @@ def assign_ugrid_topology(
             if var.dims == ds[mesh.face_node_connectivity].dims:
                 mesh.face_face_connectivity = var_name
                 break
-
 
     if mesh.face_dimension is None:
         # The face_dimension attribute specifies which netcdf dimension is used to

--- a/xarray_subset_grid/visualization/mpl_plotting.py
+++ b/xarray_subset_grid/visualization/mpl_plotting.py
@@ -117,7 +117,6 @@ def plot_sgrid(axes, ds, nodes=False, rho_points=False, edge_points=False):
     lon_var, lat_var = grid_defs["node_coordinates"].split()
     nodes_lon, nodes_lat = (ds[n] for n in grid_defs["node_coordinates"].split())
 
-
     # faces = ds[mesh_defs["face_node_connectivity"]]
 
     # if faces.shape[0] == 3:


### PR DESCRIPTION
The code as passing ruff check, but didn't have the full set of cleanup that ruff format provides.

This PR included the formatting changes after running ruff format, as configured in the pyproject.toml.

This should be a pretty good baseline for going forward.

