### PR TITLE
Add tests, etc. for py3.14 -- doesn't work now, not all deps are there.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
 ]
 
@@ -107,6 +108,7 @@ test310 = [ "dev", "py310" ]                                        # implicit: 
 test311 = [ "dev", "py311" ]
 test312 = [ "dev", "py312" ]
 test313 = [ "dev", "py313" ]
+test314 = [ "dev", "py314" ]
 
 [tool.pixi.tasks]
 
@@ -156,3 +158,6 @@ python = "~=3.12.0"
 
 [tool.pixi.feature.py313.dependencies]
 python = "~=3.13.0"
+
+[tool.pixi.feature.py314.dependencies]
+python = "~=3.14.0"


### PR DESCRIPTION
I tried adding 3.14 to the tests, but the dependencies are not yet all there on conda-forge.

It's in the `add_py3.14` branch.

I haven't figured out what's missing, but I imagine it will resolve itself before too long.

We need to keep an eye on this, and merge it when it works ...

