### PR TITLE
Fix RegularGrid issues with data_vars and decreasing coordinates

### DIFF
--- a/reproduce_issues.py
+++ b/reproduce_issues.py
@@ -1,0 +1,71 @@
+import xarray as xr
+import numpy as np
+from xarray_subset_grid.grids.regular_grid import RegularGrid
+import pytest
+
+def create_synthetic_dataset(decreasing=False):
+    """Create a synthetic dataset with regular grid."""
+    lon = np.linspace(-100, -80, 21)
+    if decreasing:
+        lat = np.linspace(50, 30, 21)
+    else:
+        lat = np.linspace(30, 50, 21)
+    
+    data = np.random.rand(21, 21)
+    
+    ds = xr.Dataset(
+        data_vars={
+            "temp": (("lat", "lon"), data),
+            "salt": (("lat", "lon"), data),
+        },
+        coords={
+            "lat": lat,
+            "lon": lon,
+        },
+    )
+    # Add cf attributes
+    ds.lat.attrs = {"standard_name": "latitude", "units": "degrees_north"}
+    ds.lon.attrs = {"standard_name": "longitude", "units": "degrees_east"}
+    ds.temp.attrs = {"standard_name": "sea_water_temperature"}
+    
+    return ds
+
+def test_data_vars_error():
+    print("Testing data_vars error...")
+    ds = create_synthetic_dataset()
+    # Ensure it is recognized as a RegularGrid
+    assert RegularGrid.recognize(ds)
+    
+    # Access xsg accessor
+    try:
+        data_vars = ds.xsg.data_vars
+        print(f"data_vars: {data_vars}")
+    except Exception as e:
+        print(f"Caught expected error in data_vars: {e}")
+        # import traceback
+        # traceback.print_exc()
+
+def test_decreasing_coords():
+    print("\nTesting decreasing coordinates support...")
+    ds = create_synthetic_dataset(decreasing=True)
+    assert RegularGrid.recognize(ds)
+    
+    # bbox: (min_lon, min_lat, max_lon, max_lat)
+    bbox = (-95, 35, -85, 45)
+    
+    try:
+        subset = ds.xsg.subset_bbox(bbox)
+        print(f"Subset size: {subset.sizes}")
+        
+        # Check if subset has data
+        if subset.sizes["lat"] == 0 or subset.sizes["lon"] == 0:
+            print("FAILURE: Subset has dimension size 0")
+        else:
+            print("SUCCESS: Subset has data")
+            
+    except Exception as e:
+        print(f"Caught unexpected error in decreasing coords subsetting: {e}")
+
+if __name__ == "__main__":
+    test_data_vars_error()
+    test_decreasing_coords()

--- a/xarray_subset_grid/grids/regular_grid.py
+++ b/xarray_subset_grid/grids/regular_grid.py
@@ -48,18 +48,29 @@ class RegularGridBBoxSelector(Selector):
     """Selector for regular lat/lng grids."""
 
     bbox: tuple[float, float, float, float]
-    _longitude_selection: slice
-    _latitude_selection: slice
 
     def __init__(self, bbox: tuple[float, float, float, float]):
         super().__init__()
         self.bbox = bbox
-        self._longitude_selection = slice(bbox[0], bbox[2])
-        self._latitude_selection = slice(bbox[1], bbox[3])
+
+    def _get_slice(self, coord: xr.DataArray, min_val: float, max_val: float) -> slice:
+        """Get the slice for the given coordinate."""
+        if coord[0] < coord[-1]:
+            # Increasing
+            return slice(min_val, max_val)
+        else:
+            # Decreasing
+            return slice(max_val, min_val)
 
     def select(self, ds: xr.Dataset) -> xr.Dataset:
         """Perform the selection on the dataset."""
-        return ds.cf.sel(lon=self._longitude_selection, lat=self._latitude_selection)
+        lon = ds.cf["longitude"]
+        lat = ds.cf["latitude"]
+
+        lon_slice = self._get_slice(lon, self.bbox[0], self.bbox[2])
+        lat_slice = self._get_slice(lat, self.bbox[1], self.bbox[3])
+
+        return ds.cf.sel(lon=lon_slice, lat=lat_slice)
 
 
 class RegularGrid(Grid):
@@ -102,13 +113,17 @@ class RegularGrid(Grid):
         """
         lat = ds.cf.coordinates["latitude"][0]
         lon = ds.cf.coordinates["longitude"][0]
-        return {
-            var
-            for var in ds.data_vars
-            if var not in {lat, lon}
-            and "latitude" in var.cf.coordinates
-            and "longitude" in var.cf.coordinates
-        }
+        valid_vars = set()
+        for var_name in ds.data_vars:
+            if var_name in {lat, lon}:
+                continue
+            
+            # Access the variable to check attributes
+            var = ds[var_name]
+            if "latitude" in var.cf.coordinates and "longitude" in var.cf.coordinates:
+                valid_vars.add(var_name)
+        
+        return valid_vars
 
     def compute_polygon_subset_selector(
         self, ds: xr.Dataset, polygon: list[tuple[float, float]], name: str = None


### PR DESCRIPTION
This PR fixes multiple issues in RegularGrid that were causing errors and incorrect subsetting.

- Fixes the data_vars logic, which was broken and raising errors due to incorrect access on variable names.
- Adds proper support for grids where latitude or longitude coordinates are decreasing instead of increasing.
- Removes assumptions about static slice direction and computes slices dynamically based on coordinate order.

The fixes were verified using a reproduction script and existing tests to ensure no regressions.

Fixes #97 