### PR TITLE
fix: correct reversed arguments in warnings.warn call

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -145,5 +145,5 @@ def test_assign_ugrid_topology_warns_with_deprecation_warning(monkeypatch):
     assert result == "ok"
     assert len(caught) == 1
     assert caught[0].category is DeprecationWarning
-    assert "assign_grid_topology" in str(caught[0].message)
+    assert "assign_ugrid_topology" in str(caught[0].message)
     assert os.path.basename(caught[0].filename) == "test_utils.py"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,11 @@
 import os
+import warnings
 
 import numpy as np
 import pytest
 
 from xarray_subset_grid.utils import (
+    assign_ugrid_topology,
     normalize_bbox_x_coords,
     normalize_polygon_x_coords,
     ray_tracing_numpy,
@@ -125,3 +127,23 @@ def test_ray_tracing_numpy():
     result = ray_tracing_numpy(points[:, 0], points[:, 1], poly)
 
     assert np.array_equal(result, [False, True, False])
+
+
+def test_assign_ugrid_topology_warns_with_deprecation_warning(monkeypatch):
+    def fake_assign_ugrid_topology(*args, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr(
+        "xarray_subset_grid.grids.ugrid.assign_ugrid_topology",
+        fake_assign_ugrid_topology,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = assign_ugrid_topology(None)
+
+    assert result == "ok"
+    assert len(caught) == 1
+    assert caught[0].category is DeprecationWarning
+    assert "assign_grid_topology" in str(caught[0].message)
+    assert os.path.basename(caught[0].filename) == "test_utils.py"

--- a/xarray_subset_grid/utils.py
+++ b/xarray_subset_grid/utils.py
@@ -97,10 +97,11 @@ def ray_tracing_numpy(x, y, poly):
 # this placeholder for backwards compatibility for a brief period
 def assign_ugrid_topology(*args, **kwargs):
     warnings.warn(
-        DeprecationWarning,
         "The function `assign_grid_topology` has been moved to the "
         "`grids.ugrid` module. It will not be able to be called from "
         "the utils `module` in the future.",
+        DeprecationWarning,
+        stacklevel=2,
     )
     from .grids.ugrid import assign_ugrid_topology
 

--- a/xarray_subset_grid/utils.py
+++ b/xarray_subset_grid/utils.py
@@ -97,10 +97,10 @@ def ray_tracing_numpy(x, y, poly):
 # this placeholder for backwards compatibility for a brief period
 def assign_ugrid_topology(*args, **kwargs):
     warnings.warn(
-        "The function `assign_grid_topology` has been moved to the "
+        "The function `assign_ugrid_topology` has been moved to the "
         "`grids.ugrid` module. It will not be able to be called from "
-        "the utils `module` in the future.",
-        DeprecationWarning,
+        "the utils module in the future.",
+        category=DeprecationWarning,
         stacklevel=2,
     )
     from .grids.ugrid import assign_ugrid_topology


### PR DESCRIPTION
## Summary
This PR fixes the deprecated compatibility wrapper so warning emission works correctly.

## Problem
The warnings.warn positional arguments were reversed. That makes Python treat a string as the warning category, which raises:
**TypeError: category must be a Warning subclass, not 'str'.**

## Changes

1. Put the warning message in the first argument position.
2. Pass DeprecationWarning as the category.
3. Add stacklevel=2 so the warning location points to caller code.
4. Add a focused regression test for warning category, message text, and caller location behavior.

## Validation

1. Utility tests pass locally.
2. Lint checks pass locally for the changed files.