### PR TITLE
fix: check self._grid instead of self._ds in data_vars property

### DIFF
--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -1,0 +1,17 @@
+import pytest
+import xarray as xr
+
+import xarray_subset_grid.accessor  # noqa: F401
+
+
+def test_data_vars_returns_empty_set_when_grid_not_recognized():
+    ds = xr.Dataset(
+        data_vars={"foo": ("x", [1, 2, 3])},
+        coords={"x": [0, 1, 2]},
+    )
+
+    with pytest.warns(UserWarning, match="no grid type found in this dataset"):
+        accessor = ds.xsg
+
+    assert accessor.grid is None
+    assert accessor.data_vars == set()

--- a/xarray_subset_grid/accessor.py
+++ b/xarray_subset_grid/accessor.py
@@ -1,9 +1,9 @@
 import warnings
+from typing import TYPE_CHECKING
 
 # from typing import Optional, Union
 import numpy as np
 import xarray as xr
-from xarray.core.coordinates import DatasetCoordinates
 
 from xarray_subset_grid.grid import Grid
 from xarray_subset_grid.grids import (
@@ -15,6 +15,9 @@ from xarray_subset_grid.grids import (
     SGrid,
     UGrid,
 )
+
+if TYPE_CHECKING:
+    from xarray.core.coordinates import DatasetCoordinates
 
 _grid_impls = [
     FVCOMGrid,
@@ -84,11 +87,11 @@ class GridDatasetAccessor:
         return set()
 
     @property
-    def coords(self) -> DatasetCoordinates:
+    def coords(self) -> "DatasetCoordinates":
         return self._ds.coords
 
     @property
-    def grid_vars(self) -> set[str] | list[str]:
+    def grid_vars(self) -> set[str]:
         """List of grid variables.
 
         These variables are used to define the grid and thus should be

--- a/xarray_subset_grid/accessor.py
+++ b/xarray_subset_grid/accessor.py
@@ -3,6 +3,7 @@ import warnings
 # from typing import Optional, Union
 import numpy as np
 import xarray as xr
+from xarray.core.coordinates import DatasetCoordinates
 
 from xarray_subset_grid.grid import Grid
 from xarray_subset_grid.grids import (
@@ -78,18 +79,16 @@ class GridDatasetAccessor:
         data analysis. These can be discarded when subsetting the
         dataset when they are not needed.
         """
-        if self._ds:
+        if self._grid:
             return self._grid.data_vars(self._ds)
         return set()
 
     @property
-    def coords(self) -> set[str]:
-        if self._ds:
-            return self._ds.coords
-        return set()
+    def coords(self) -> DatasetCoordinates:
+        return self._ds.coords
 
     @property
-    def grid_vars(self) -> set[str]:
+    def grid_vars(self) -> set[str] | list[str]:
         """List of grid variables.
 
         These variables are used to define the grid and thus should be


### PR DESCRIPTION
## Summary
This PR fixes the accessor guard used by data_vars when no grid implementation is recognized for a dataset.

## Problem
The data_vars property checked self._ds, which is always present after accessor initialization. In no-grid cases, that guard still allowed a call through self._grid, which can be None.

## Changes

1. Update data_vars guard to check self._grid before delegating.
2. Add a focused regression test for datasets where no grid type is recognized.
3. Align nearby accessor return annotations with actual return types to resolve return-type diagnostics in editor/type checking.

## Validation

1. pre-commit hooks pass on changed files.
2. Targeted regression and related grid accessor tests pass locally.