### PR TITLE
Add pre-commit pixi task for devs

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -53,6 +53,7 @@ pooch = "*"
 
 [feature.dev.tasks]
 lint = "ruff check tests xarray_subset_grid"
+pre_commit = "pre-commit run --all-files"
 test = { cmd = ["pytest", "tests/"], depends-on = ["download"] }
 download = "python download_test_data.py"
 test_all = { cmd = "pytest --online tests/", depends-on = ["download"] }


### PR DESCRIPTION
This will make it easier for developers to test pre-commit checks locally. All we need to do is to run:

```
pixi run --environment test314 pre_commit
```