### PR TITLE
Use platforms to comply with latest pixi

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,12 @@
 [workspace]
 name = "xarray_subset_grid"
 channels = [ "conda-forge" ]
-platforms = [ "linux-64", "osx-arm64", "osx-64", "win-64" ]
+platforms = [
+    "linux-64",
+    { platform = "osx-64", macos="11.0" },
+    "osx-arm64",
+    "win-64",
+]
 
 [pypi-dependencies]
 xarray_subset_grid = { path = ".", editable = true }
@@ -30,9 +35,6 @@ test312 = [ "dev", "py312" ]
 test313 = [ "dev", "py313" ]
 test314 = [ "dev", "py314" ]
 testcov = [ "dev", "py314" ]
-
-[system-requirements]
-macos = "11.0"
 
 [tasks]
 


### PR DESCRIPTION
The `system-requirements` field is deprecated.