### PR TITLE
Types take 2

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,27 @@
+name: mypy type hint checks
+
+# no permissions by default
+permissions: {}
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f  # v0.10.0
+
+      - name: Tests
+        run: >
+          pixi run --frozen --environment test314 mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,14 +16,20 @@ repos:
   - id: mypy
     # In the next typing PR we will add the extra dependencies for a better assessment, then
     # we'll try strict, then removing ignore missing imports.
-    # args: [--strict, --ignore-missing-imports]
+    args: [ --install-types, --non-interactive ]
     additional_dependencies:
-      - pandas-stubs
-    #   - cf-xarray
-    #   - netcdf4
-    #   - xarray>=2024.6
-
-    exclude: 'docs/source/conf\.py'
+      - cf-xarray
+      - netcdf4
+      - xarray>=2024.6
+      - matplotlib
+    exclude: |
+      (?x)(
+        ^build/
+        | conf\.py$
+        | ^tests/
+        | ^docs/
+        | ^profiling/
+      )
 
 - repo: https://github.com/keewis/blackdoc
   rev: v0.4.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
       (?x)(
         ^build/
         | conf\.py$
+        | _version\.py$
         | ^tests/
         | ^docs/
         | ^profiling/
@@ -55,7 +56,7 @@ repos:
     - id: ruff-format
 
 - repo: https://github.com/woodruffw/zizmor-pre-commit
-  rev: v1.26.1
+  rev: v1.27.0
   hooks:
     - id: zizmor
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,28 +10,6 @@ repos:
     - id: check-added-large-files
       exclude_types: [yaml]
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v2.3.0
-  hooks:
-  - id: mypy
-    # In the next typing PR we will add the extra dependencies for a better assessment, then
-    # we'll try strict, then removing ignore missing imports.
-    args: [ --install-types, --non-interactive ]
-    additional_dependencies:
-      - cf-xarray
-      - netcdf4
-      - xarray>=2024.6
-      - matplotlib
-    exclude: |
-      (?x)(
-        ^build/
-        | conf\.py$
-        | _version\.py$
-        | ^tests/
-        | ^docs/
-        | ^profiling/
-      )
-
 - repo: https://github.com/keewis/blackdoc
   rev: v0.4.6
   hooks:

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,6 +31,7 @@ pre_commit = "pre-commit run --all-files"
 test = { cmd = ["pytest", "tests/"] }
 test_all = { cmd = "pytest --online tests/" }
 test_cov = { cmd = "pytest --cov=xarray_subset_grid tests" }
+mypy = { cmd = "mypy xarray_subset_grid" }
 
 [feature.py311.dependencies]
 python = "~=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 optional-dependencies.dev = [
   "jupyter",
   "matplotlib",
+  "mypy",
   "myst-nb",
   "pooch",
   "pre-commit",
@@ -49,6 +50,7 @@ optional-dependencies.dev = [
   "sphinx-autodoc-typehints",
   "sphinx-rtd-theme",
   "sphinx",
+  "types-python-dateutil",
 ]
 
 optional-dependencies.examples = [ "fsspec", "h5netcdf", "matplotlib", "s3fs", "zarr<3" ]

--- a/xarray_subset_grid/__init__.py
+++ b/xarray_subset_grid/__init__.py
@@ -1,10 +1,12 @@
-# module
-from . import grid  # noqa
-from . import grids  # noqa
-from . import utils  # noqa
-from . import accessor  # noqa
+from . import accessor, grid, grids, utils
+from ._version import __version__  # type: ignore[import-untyped]
 from .selector import Selector
 
-from ._version import __version__  # noqa
-
-__all__ = ["Selector"]
+__all__ = [
+    "__version__",
+    "accessor",
+    "grid",
+    "grids",
+    "Selector",
+    "utils",
+]

--- a/xarray_subset_grid/accessor.py
+++ b/xarray_subset_grid/accessor.py
@@ -1,5 +1,5 @@
 import warnings
-from collections.abc import Iterable
+from collections.abc import Hashable, Iterable
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -75,7 +75,7 @@ class GridDatasetAccessor:
         return self._grid
 
     @property
-    def data_vars(self) -> set[str]:
+    def data_vars(self) -> set[Hashable]:
         """List of data variables.
 
         These variables exist on the grid and are available to used for
@@ -104,7 +104,7 @@ class GridDatasetAccessor:
         return set()
 
     @property
-    def extra_vars(self) -> set[str]:
+    def extra_vars(self) -> set[Hashable]:
         if self._grid:
             return self._grid.extra_vars(self._ds)
         return set()

--- a/xarray_subset_grid/accessor.py
+++ b/xarray_subset_grid/accessor.py
@@ -1,9 +1,12 @@
 import warnings
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
-# from typing import Optional, Union
 import numpy as np
 import xarray as xr
+
+if TYPE_CHECKING:
+    from xarray.core.coordinates import DatasetCoordinates
 
 from xarray_subset_grid.grid import Grid
 from xarray_subset_grid.grids import (
@@ -84,7 +87,7 @@ class GridDatasetAccessor:
         return set()
 
     @property
-    def coords(self) -> set[str]:
+    def coords(self) -> set[str] | "DatasetCoordinates":
         if self._ds:
             return self._ds.coords
         return set()

--- a/xarray_subset_grid/grid.py
+++ b/xarray_subset_grid/grid.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+from collections.abc import Hashable, Iterable
 
 import numpy as np
 import xarray as xr
@@ -35,7 +35,7 @@ class Grid(ABC):
         return set()
 
     @abstractmethod
-    def data_vars(self, ds: xr.Dataset) -> set[str]:
+    def data_vars(self, ds: xr.Dataset) -> set[Hashable]:
         """List of data variables.
 
         These variables exist on the grid and are available to used for
@@ -44,7 +44,7 @@ class Grid(ABC):
         """
         return set()
 
-    def extra_vars(self, ds: xr.Dataset) -> set[str]:
+    def extra_vars(self, ds: xr.Dataset) -> set[Hashable]:
         """List of variables that are not grid vars or data vars.
 
         These variables area ll the ones in the dataset that are not

--- a/xarray_subset_grid/grids/fvcom_grid.py
+++ b/xarray_subset_grid/grids/fvcom_grid.py
@@ -96,11 +96,11 @@ class FVCOMGrid(UGrid):
         selections = {}
         if "siglay" in ds.dims:
             siglay = ds["siglay"].isel(node=0)
-            elevation_index = int(np.absolute(siglay - level).argmin(axis=0).values)
+            elevation_index = int(np.absolute((siglay - level).to_numpy()).argmin(axis=0))
             selections["siglay"] = elevation_index
         if "siglev" in ds.dims:
             siglev = ds["siglev"].isel(node=0)
-            elevation_index = int(np.absolute(siglev - level).argmin(axis=0).values)
+            elevation_index = int(np.absolute((siglev - level).to_numpy()).argmin(axis=0))
             selections["siglev"] = elevation_index
 
         return ds.isel(selections)
@@ -127,13 +127,13 @@ class FVCOMGrid(UGrid):
         if "siglay" in ds.dims:
             siglay = ds["siglay"].isel(node=0)
             elevation_indexes = [
-                int(np.absolute(siglay - level).argmin(axis=0).values) for level in levels
+                int(np.absolute((siglay - level).to_numpy()).argmin(axis=0)) for level in levels
             ]
             selections["siglay"] = slice(elevation_indexes[0], elevation_indexes[1])
         if "siglev" in ds.dims:
             siglev = ds["siglev"].isel(node=0)
             elevation_index = [
-                int(np.absolute(siglev - level).argmin(axis=0).values) for level in levels
+                int(np.absolute((siglev - level).to_numpy()).argmin(axis=0)) for level in levels
             ]
             selections["siglev"] = slice(elevation_index[0], elevation_index[1])
 

--- a/xarray_subset_grid/grids/regular_grid.py
+++ b/xarray_subset_grid/grids/regular_grid.py
@@ -9,6 +9,8 @@ The grid is defined by two 1-d arrays.
 * delta_lat and delta_lon do not have to be constant.
 """
 
+from collections.abc import Hashable
+
 import numpy as np
 import xarray as xr
 
@@ -137,7 +139,7 @@ class RegularGrid(Grid):
         lon = ds.cf.coordinates["longitude"][0]
         return {lat, lon}
 
-    def data_vars(self, ds: xr.Dataset) -> set[str]:
+    def data_vars(self, ds: xr.Dataset) -> set[Hashable]:
         """Set of data variables.
 
         These variables exist on the grid and are available to used for

--- a/xarray_subset_grid/grids/regular_grid_2d.py
+++ b/xarray_subset_grid/grids/regular_grid_2d.py
@@ -3,6 +3,7 @@
 # do we need a separate class for this?
 # This doesn't appear, right now, to check for depth to dedermine if it's 2D
 
+from collections.abc import Hashable
 
 import numpy as np
 import xarray as xr
@@ -69,7 +70,7 @@ class RegularGrid2d(Grid):
         lon = ds.cf.coordinates["longitude"][0]
         return {lat, lon}
 
-    def data_vars(self, ds: xr.Dataset) -> set[str]:
+    def data_vars(self, ds: xr.Dataset) -> set[Hashable]:
         """Set of data variables.
 
         These variables exist on the grid and are available to used for

--- a/xarray_subset_grid/grids/sgrid.py
+++ b/xarray_subset_grid/grids/sgrid.py
@@ -44,10 +44,9 @@ class SGridSelector(Selector):
             ds_out.append(ds_subset)
 
         # Merge the subsetted datasets
-        ds_out = xr.merge(ds_out)
+        _ds_out = xr.merge(ds_out)
 
-        ds_out = ds_out.assign({self._grid_topology_key: self._grid_topology})
-        return ds_out
+        return _ds_out.assign({self._grid_topology_key: self._grid_topology})
 
 
 class SGrid(Grid):

--- a/xarray_subset_grid/grids/sgrid.py
+++ b/xarray_subset_grid/grids/sgrid.py
@@ -1,3 +1,5 @@
+from collections.abc import Hashable
+
 import numpy as np
 import xarray as xr
 
@@ -11,7 +13,7 @@ class SGridSelector(Selector):
 
     _grid_topology_key: str
     _grid_topology: xr.DataArray
-    _subset_masks: list[tuple[list[str], xr.DataArray]]
+    _subset_masks: list[tuple[list[Hashable], xr.DataArray]]
 
     def __init__(
         self,
@@ -19,7 +21,7 @@ class SGridSelector(Selector):
         polygon: list[tuple[float, float]] | np.ndarray,
         grid_topology_key: str,
         grid_topology: xr.DataArray,
-        subset_masks: list[tuple[list[str], xr.DataArray]],
+        subset_masks: list[tuple[list[Hashable], xr.DataArray]],
     ):
         super().__init__()
         self.name = name
@@ -82,7 +84,7 @@ class SGrid(Grid):
             grid_coords.extend(coords)
         return set(grid_coords)
 
-    def data_vars(self, ds: xr.Dataset) -> set[str]:
+    def data_vars(self, ds: xr.Dataset) -> set[Hashable]:
         """Set of data variables.
 
         These variables exist on the grid and are available to used for
@@ -103,7 +105,7 @@ class SGrid(Grid):
     ) -> Selector:
         grid_topology_key = ds.cf.cf_roles["grid_topology"][0]
         grid_topology = ds[grid_topology_key]
-        subset_masks: list[tuple[list[str], xr.DataArray]] = []
+        subset_masks: list[tuple[list[Hashable], xr.DataArray]] = []
 
         node_info = _get_location_info_from_topology(grid_topology, "node")
         node_dims = node_info["dims"]
@@ -147,9 +149,8 @@ class SGrid(Grid):
                 if "lon" in ds[c].standard_name.lower():
                     lon = ds[c]
             padding = info["padding"]
-            arranged_padding: list[int | str] = []
-            arranged_padding = [padding[d] for d in lon.dims]
-            arranged_padding = [0 if p == "none" or p == "low" else 1 for p in arranged_padding]
+            add_padding = [padding[d] for d in lon.dims]
+            arranged_padding = [0 if p == "none" or p == "low" else 1 for p in add_padding]
             mask = np.zeros(lon.shape, dtype=bool)
             mask[
                 index_bounding_box[0][0] : index_bounding_box[0][1] + arranged_padding[0],
@@ -167,7 +168,9 @@ class SGrid(Grid):
         )
 
 
-def _get_location_info_from_topology(grid_topology: xr.DataArray, location) -> dict[str, str]:
+def _get_location_info_from_topology(
+    grid_topology: xr.DataArray, location
+) -> dict[str, list | dict]:
     """Get the dimensions and coordinates for a given location from the grid_topology"""
     dim_str = grid_topology.attrs.get(f"{location}_dimensions", None)
     coord_str = grid_topology.attrs.get(f"{location}_coordinates", None)

--- a/xarray_subset_grid/grids/sgrid.py
+++ b/xarray_subset_grid/grids/sgrid.py
@@ -44,9 +44,9 @@ class SGridSelector(Selector):
             ds_out.append(ds_subset)
 
         # Merge the subsetted datasets
-        _ds_out = xr.merge(ds_out)
+        ds_merged = xr.merge(ds_out)
 
-        return _ds_out.assign({self._grid_topology_key: self._grid_topology})
+        return ds_merged.assign({self._grid_topology_key: self._grid_topology})
 
 
 class SGrid(Grid):
@@ -174,11 +174,11 @@ def _get_location_info_from_topology(grid_topology: xr.DataArray, location) -> d
     if dim_str is None or coord_str is None:
         raise ValueError(f"Could not find {location} dimensions or coordinates")
     # Remove padding for now
-    _dims_only = " ".join([v for v in dim_str.split(" ") if "(" not in v and ")" not in v])
-    if ":" in _dims_only:
-        dims_only = [s.replace(":", "") for s in _dims_only.split(" ") if ":" in s]
+    dimensions = " ".join([v for v in dim_str.split(" ") if "(" not in v and ")" not in v])
+    if ":" in dimensions:
+        dims_only = [s.replace(":", "") for s in dimensions.split(" ") if ":" in s]
     else:
-        dims_only = _dims_only.split(" ")
+        dims_only = dimensions.split(" ")
 
     padding = dim_str.replace(":", "").split(")")
     pdict = {}
@@ -216,12 +216,16 @@ def _get_sgrid_dim_coord_names(
     for k, v in grid_topology.attrs.items():
         if "_dimensions" in k:
             # Remove padding for now
-            _d = " ".join([v for v in v.split(" ") if "(" not in v and ")" not in v])
-            if ":" in _d:
-                d = [_d.replace(":", "") for _d in _d.split(" ") if ":" in _d]
+            dimension = " ".join([v for v in v.split(" ") if "(" not in v and ")" not in v])
+            if ":" in dimension:
+                dim = [
+                    dimension.replace(":", "")
+                    for dimension in dimension.split(" ")
+                    if ":" in dimension
+                ]
             else:
-                d = _d.split(" ")
-            dims.append(d)
+                dim = dimension.split(" ")
+            dims.append(dim)
         elif "_coordinates" in k:
             coords.append(v.split(" "))
 

--- a/xarray_subset_grid/grids/ugrid.py
+++ b/xarray_subset_grid/grids/ugrid.py
@@ -477,8 +477,8 @@ def assign_ugrid_topology(
         raise ValueError(f"start_index must be 0 or 1, not {mesh.start_index}")
 
     # assign the start_index to all the grid variables
-    for _var in (v for v in ALL_MESH_VARS if "connectivity" in v):
-        var_name = getattr(mesh, _var)
+    for variable in (v for v in ALL_MESH_VARS if "connectivity" in v):
+        var_name = getattr(mesh, variable)
         if var_name:
             try:
                 ds_var = ds[var_name]

--- a/xarray_subset_grid/grids/ugrid.py
+++ b/xarray_subset_grid/grids/ugrid.py
@@ -477,12 +477,12 @@ def assign_ugrid_topology(
         raise ValueError(f"start_index must be 0 or 1, not {mesh.start_index}")
 
     # assign the start_index to all the grid variables
-    for var in (v for v in ALL_MESH_VARS if "connectivity" in v):
-        var_name = getattr(mesh, var)
+    for _var in (v for v in ALL_MESH_VARS if "connectivity" in v):
+        var_name = getattr(mesh, _var)
         if var_name:
             try:
-                var = ds[var_name]
-                var.attrs.setdefault("start_index", mesh.start_index)
+                ds_var = ds[var_name]
+                ds_var.attrs.setdefault("start_index", mesh.start_index)
             except KeyError:
                 warnings.warn(f"{var_name} in mesh_topology variable, but not in dataset")
 

--- a/xarray_subset_grid/grids/ugrid.py
+++ b/xarray_subset_grid/grids/ugrid.py
@@ -1,4 +1,5 @@
 import warnings
+from collections.abc import Hashable
 from types import SimpleNamespace
 
 import numpy as np
@@ -143,7 +144,7 @@ class UGrid(Grid):
                     vars.add(mesh.attrs[var_name])
         return vars
 
-    def data_vars(self, ds: xr.Dataset) -> set[str]:
+    def data_vars(self, ds: xr.Dataset) -> set[Hashable]:
         """Set of data variables.
 
         These variables exist on the grid and are available to used for

--- a/xarray_subset_grid/utils.py
+++ b/xarray_subset_grid/utils.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 
 import cf_xarray  # noqa
-import cftime
+
+# See https://github.com/Unidata/cftime/issues/349
+import cftime  # type: ignore[import-untyped]
 import numpy as np
 import xarray as xr
 from dateutil.parser import parse as parsetime


### PR DESCRIPTION
This PR fix the remaining type issues for a full realized env with all the dependencies.  There is not much we can do for `cftime` b/c there are no stubs there.

Also, we need to make a call on the generic `Hashable` types for the xarray datavars, dims, etc. See https://github.com/pydata/xarray/discussions/4834. Or options are:

- Add inline ignore comments these 8 errors associated to the generic `Hashable` and wait for a better fix upstream;
- Remove `xarray` from the mypy env and add `--ignore-missing-imports `;
- Use `typing.cast` and cast them to `str`.
- Use Hashable instead of `str`.

~~I prefer option to ignore them for now b/c it a way to explicitly remind us to revisit this in the future.~~

Edit: I went for the last option there b/c it is the cleanest I could find.